### PR TITLE
Adjust status check

### DIFF
--- a/src/Task/Drupal/ValidateSite.php
+++ b/src/Task/Drupal/ValidateSite.php
@@ -34,7 +34,7 @@ class ValidateSite extends BaseTask {
     $this->say('Checking site status for: ' . $this->siteStatus['root']);
 
     // Check that configuration is correct and Drupal 8 site is installed.
-    if ($this->siteStatus['bootstrap'] !== 'Successful') {
+    if (empty($this->siteStatus['bootstrap'])) {
       return Result::error($this, 'Site status is not valid.');
     }
 


### PR DESCRIPTION
There is problem with status check when bootstrap status is translated. Fe. on German it's "Erfolgreich", so compare to "Successful" can't be used. Based on drush command code: https://github.com/drush-ops/drush/blob/8.1.11/commands/core/core.drush.inc#L591
"bootstrap" status exists only if it's bootstrapped properly and it is sufficient to check only that property is not empty.