### PR TITLE
Add drush cr before code update

### DIFF
--- a/scripts/update-tester.php
+++ b/scripts/update-tester.php
@@ -177,13 +177,19 @@ class UpdateTester extends Tasks {
     }
     $updatePackages->run();
 
+    $absoluteDestinationDocroot = DocrootResolver::getDocroot($absoluteDestination);
+
+    // Run "drush cr" before updating code.
+    $drushCmd = $this->task(Drush::class);
+    $drushCmd->dir($absoluteDestinationDocroot);
+    $drushCmd->arg('cache-rebuild');
+    $drushCmd->run();
+
     /** @var \Robo\Task\Composer\Update $composerUpdate */
     $composerUpdate = $this->task(Update::class);
     $composerUpdate->dir($absoluteDestination);
     $composerUpdate->option('no-interaction')->option('no-dev');
     $composerUpdate->run();
-
-    $absoluteDestinationDocroot = DocrootResolver::getDocroot($absoluteDestination);
 
     /** @var \Thunder\UpdateTester\Exec\Drush $drushCmd */
     $drushCmd = $this->task(Drush::class);


### PR DESCRIPTION
Before update hooks are executed, cache should be cleared, but it should be cleared before code is updated.

There is also Drupal issue: `https://www.drupal.org/project/drupal/issues/2863986` - for that problem.

That's why we are doing following steps:
```
...
update outdated packages in composer.json (no code change yet)
drush cr
composer update
drush updb
...
```